### PR TITLE
Add: filterable capability for admin menu

### DIFF
--- a/admin/ginger.utils.php
+++ b/admin/ginger.utils.php
@@ -11,7 +11,10 @@
 add_action( 'admin_menu', 'register_ginger_menu_page' );
 function register_ginger_menu_page(){
     global $ginger_menu_hook;
-    $ginger_menu_hook = add_menu_page( 'ginger', 'Ginger Cookie', 'manage_options', 'ginger-setup', 'ginger_menu_page', plugins_url( 'ginger/img/ginger-color.png' ));
+
+	$capability = apply_filters('ginger_admin_menu_capability', 'manage_options');
+
+	$ginger_menu_hook = add_menu_page( 'ginger', 'Ginger Cookie', $capability, 'ginger-setup', 'ginger_menu_page', plugins_url( 'ginger/img/ginger-color.png' ));
     do_action("ginger_add_menu");
 
 


### PR DESCRIPTION
Hi,

to be able to enable the cookie and to change the text, one has to have the 'manage_options' capability. So, basically only an administrator can do this.

Our clients don't have this capability, and thus, cannot edit the cookie.

Would it be a nice feature to let the capability be filterable, so one can change this accordingly.

Filter name: ginger_admin_menu_capability

Example:
add_filter('ginger_admin_menu_capability', function($capability) {
	return 'delete_users';
}, 10, 1);