### PR TITLE
Renamed: $curl to $url to prevent notice and thus javascript inline error

### DIFF
--- a/addon/logger/ginger.logger.php
+++ b/addon/logger/ginger.logger.php
@@ -125,13 +125,11 @@ function ginger_add_log_variable(){
         var ginger_logger = "Y";
         var ginger_logger_url = "<?php bloginfo("url"); ?>";
         var current_url = "<?php
-            $curl = (isset($_SERVER['HTTPS']) ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+            $url = (isset($_SERVER['HTTPS']) ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
             if(filter_var($url, FILTER_VALIDATE_URL) === FALSE){
-                $curl = get_bloginfo("url");
-            }else{
-                $curl = $curl;
+                $url = get_bloginfo("url");
             }
-            echo $curl;
+            echo $url;
             ?>";
 
         function gingerAjaxLogTime(status) {


### PR DESCRIPTION
According to https://github.com/webgrafia/ginger/issues/10, there is a typo, which outputs a notice. This results in a javascript error.

Can you check this, merge, and publish it to the WordPress Plugin repo?

Thanks.