### PR TITLE
Add option to disable activity logging

### DIFF
--- a/addon/logger/ginger.logger.php
+++ b/addon/logger/ginger.logger.php
@@ -173,6 +173,10 @@ function ginger_add_log_variable(){
 
 function ginger_do_log($url = "", $status = "Y"){
     global $wpdb;
+
+    $disable_logger = get_option('ginger_policy_disable_logger', false);
+    if($disable_logger) return;
+
     if($url == "")
         $url = (isset($_SERVER['HTTPS']) ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
     if(filter_var($url, FILTER_VALIDATE_URL) === FALSE){

--- a/admin/ginger.admin.php
+++ b/admin/ginger.admin.php
@@ -66,6 +66,7 @@ if ($key=='ginger_policy'){
         update_option($key, $privacy_page_id);
     endif;
         update_option($key.'_disable_ginger', $_POST["ginger_privacy_click_scroll"]);
+        update_option($key.'_disable_logger', $_POST["ginger_disable_logger"] == '1');
 
 }else{
     update_option($key, $params);}
@@ -78,6 +79,7 @@ if ($key=='ginger_policy'):
     $options = get_option($key);
     // recupero la option per il disable click out e scroll in privacy policy page
     $options2 = get_option($key.'_disable_ginger');
+    $options_disable_logger = get_option($key.'_disable_logger');
 
 endif;
 ?>

--- a/admin/partial/policy.php
+++ b/admin/partial/policy.php
@@ -121,6 +121,26 @@
                 </p>
             </fieldset>
         </td>
+    </tr>
+    <tr>
+        <th scope="row" style="padding-left:20px;"><?php _e("Disable logging of activities and IPs", "ginger"); ?></th>
+        <td>
+            <fieldset>
+                <legend class="screen-reader-text">
+                    <span><?php _e("Disable logging of activities and IPs", "ginger"); ?></span>
+                </legend>
+                <p>
+                    <label>
+                        <input name="ginger_disable_logger" type="radio" value="1" class="tog" <?php if($options_disable_logger == "1") echo ' checked="checked" '; ?>><?php _e("Yes", "ginger"); ?>
+                    </label>
+                </p>
+                <p>
+                    <label>
+                        <input name="ginger_disable_logger" type="radio" value="0" class="tog" <?php if($options_disable_logger == "0") echo ' checked="checked" '; ?>><?php _e("No", "ginger"); ?>
+                    </label>
+                </p>
+            </fieldset>
+        </td>
     </tr>    
     </tbody>
 </table>

--- a/admin/partial/policy.php
+++ b/admin/partial/policy.php
@@ -9,7 +9,7 @@
     <tbody>
 
     <tr>
-        <th scope="row" style="padding-left:20px;">
+        <th scope="row" style="padding-left:20px;" colspan="2">
             <label>
                 <input name="choice" type="radio" value="page" onclick="javascript:select_privacy_page();" <?php if ($options != "") echo ' checked="checked" '; ?>> <?php _e("Select your privacy policy page", "ginger"); ?>
             </label>
@@ -62,7 +62,7 @@
         </td>
     </tr>
     <tr>
-        <th scope="row" style="padding-left:20px;">
+        <th scope="row" style="padding-left:20px;" colspan="2">
             <label>
                 <input name="choice" type="radio" value="new_page" onclick="javascript:new_privacy_page();"><?php _e("or create your privacy policy page", "ginger"); ?>
             </label>
@@ -105,9 +105,7 @@
     </tr>
     <tr>
         <th scope="row" style="padding-left:20px;"><?php _e("Disable Click-out and Scroll to accept cookies in Privacy Policy page", "ginger"); ?></th>
-    </tr>
-    <tr>
-        <td colspan="2"  style="padding-left:20px;">
+        <td>
             <fieldset>
                 <p>
                     <label>

--- a/uninstall.php
+++ b/uninstall.php
@@ -10,3 +10,4 @@ if ( ! current_user_can( 'activate_plugins' ) )
 delete_option('ginger_general');
 delete_option('ginger_banner');
 delete_option('ginger_policy');
+delete_option('ginger_policy_disable_logger');


### PR DESCRIPTION
fixes https://github.com/webgrafia/ginger/issues/14

Hi, I have tried to come up with a new option. As I do not have much experience with PHP or Wordpress plugins, please have a look if you can make some time.

The idea is to have a new option on the policy admin page and to not execute the activity logging if the option `ginger_policy_disable_logger` is set to `true`. 

I have manually tested it with my Wordpress installation (4.9.5) and as far as I can tell, it works fine.