### PR TITLE
Fix script not restored when cache is enabled

### DIFF
--- a/front/gingerfront.core.php
+++ b/front/gingerfront.core.php
@@ -93,9 +93,7 @@ function ginger_run(){
     endif;
 
     if(!(isset($option_ginger_general['enable_ginger']) && $option_ginger_general['enable_ginger'] == 1)) return;
-    if(isset($_COOKIE['ginger-cookie']) && $_COOKIE['ginger-cookie'] == 'Y'):
-        if(isset($option_ginger_general['ginger_cache']) && $option_ginger_general['ginger_cache'] == 'no') return;
-    endif;
+    if(isset($_COOKIE['ginger-cookie']) && $_COOKIE['ginger-cookie'] == 'Y') return;
  
 
     if(isset($option_ginger_general['ginger_opt']) && $option_ginger_general['ginger_opt'] == 'in'):


### PR DESCRIPTION
Fix #24 
When cache option is set to yes and the banner is accepted, some script aren't restored.

The problem was due by this line:
`        if (isset($option_ginger_general['ginger_cache']) && $option_ginger_general['ginger_cache'] == 'no') return;`

If the cache option was set to "yes",  the execution continue to ginger_parse_dom also when the banner was accepted, why?